### PR TITLE
Fix camel-case conversion for nested vectors

### DIFF
--- a/src/cljs_react_material_ui/core.cljs
+++ b/src/cljs_react_material_ui/core.cljs
@@ -12,10 +12,8 @@
   (and (vector? x) (= (count x) 2)))
 
 (defn ^:private walk-map-keys [f props]
-  (walk/prewalk (fn [x]
-                  (if (map-entry? x)
-                    [(f (key x)) (val x)]
-                    x)) props))
+  (let [f' (fn [[k v]] [(f k) v])]
+    (walk/postwalk (fn [x] (if (map? x) (into {} (map f' x)) x)) props)))
 
 (def props-kebab->camel->js (comp clj->js (partial walk-map-keys kebab->camel)))
 


### PR DESCRIPTION
The map-entry? method may sometimes try to convert the first element
of a vector property for a mui component (such as :nested-list or
:actions) to camel case resulting in errors when the value isn't
nameable.

This patch changes the prewalk to a postwalk that first tests for a map
then maps over its keys applying the camel case function.

As an example I had this code that was erroring before my patch:

```clojure
(mui/dialog {:title "Delete?"
             :key "dialog"
             :modal false
             :open (om/get-state this :open-delete)
             :actions [(mui/raised-button {:label "Back"
                                           :key "back"
                                           :on-touch-tap #(om/update-state! this assoc :open-delete false)})
                       (mui/raised-button {:label "Delete"
                                           :key "delete"
                                           :on-touch-tap #(delete-and-redirect this)})]
             :on-request-close #(om/update-state! this assoc :open-delete false)})

                                          
```