### PR TITLE
Fixing the "usage" example as it's wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Update your Clojurescript version (>= 1.9.908)
   (ns cljs-react-material-ui-example.core
     (:require [cljsjs.material-ui]  ; I recommend adding this at the beginning of core file
                                     ;  so React is always loaded first. It's not always needed
-              [cljs-react-material-ui.core :as ui]
+              [cljs-react-material-ui.reagent :as ui]
               [cljs-react-material-ui.icons :as ic]))   ; SVG icons that comes with MaterialUI
                                                         ; Including icons is not required
   ```


### PR DESCRIPTION
The usage example has a mistake and makes it so that when people do copy/paste, they end up with a wrong example.